### PR TITLE
Added gitattribute file because vercel is spitting 404 for my blender…

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.glb binary


### PR DESCRIPTION
… glb object. This turns the glb into binary